### PR TITLE
Feat/#16 로그인 인증 + 사용자 정보 전달

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Backend CD # actions 이름
 
 on:
   push:
-    branches: [ feat/#9 ]
+    branches: [ feat/#16 ]
 
 jobs:
   deploy:

--- a/core/src/main/java/com/pocket/core/aop/annotation/NameAuthenticated.java
+++ b/core/src/main/java/com/pocket/core/aop/annotation/NameAuthenticated.java
@@ -1,0 +1,11 @@
+package com.pocket.core.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NameAuthenticated {
+}

--- a/core/src/main/java/com/pocket/core/aop/aspect/NameAuthenticationAspect.java
+++ b/core/src/main/java/com/pocket/core/aop/aspect/NameAuthenticationAspect.java
@@ -1,0 +1,37 @@
+package com.pocket.core.aop.aspect;
+
+import com.pocket.core.exception.jwt.CustomUserDetails;
+import com.pocket.core.exception.jwt.SecurityCustomException;
+import com.pocket.core.exception.jwt.SecurityErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class NameAuthenticationAspect {
+
+    @Pointcut("@annotation(com.pocket.core.aop.annotation.NameAuthenticated)")
+    public void nameAuthenticated() {
+    }
+
+    @Before("nameAuthenticated()")
+    public void authenticateName() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = null;
+
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            email = userDetails.getEmail();
+        }
+
+        if (email == null) {
+            throw new SecurityCustomException(SecurityErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/core/src/main/java/com/pocket/core/exception/jwt/CustomUserDetails.java
+++ b/core/src/main/java/com/pocket/core/exception/jwt/CustomUserDetails.java
@@ -1,0 +1,7 @@
+package com.pocket.core.exception.jwt;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface CustomUserDetails extends UserDetails {
+    String getEmail(); // 이메일 주소를 반환하는 메소드 추가
+}

--- a/core/src/main/java/com/pocket/core/exception/user/UserCustomException.java
+++ b/core/src/main/java/com/pocket/core/exception/user/UserCustomException.java
@@ -1,0 +1,22 @@
+package com.pocket.core.exception.user;
+
+import com.pocket.core.exception.common.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserCustomException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    private final Throwable cause;
+
+    public UserCustomException(BaseErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.cause = null;
+    }
+
+    public UserCustomException(BaseErrorCode errorCode, Throwable cause) {
+        this.errorCode = errorCode;
+        this.cause = cause;
+    }
+}

--- a/core/src/main/java/com/pocket/core/exception/user/UserErrorCode.java
+++ b/core/src/main/java/com/pocket/core/exception/user/UserErrorCode.java
@@ -1,0 +1,24 @@
+package com.pocket.core.exception.user;
+
+import com.pocket.core.exception.common.ApiResponse;
+import com.pocket.core.exception.common.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+	NO_USER_INFO(HttpStatus.BAD_REQUEST, "400", "사용자 정보가 존재하지 않습니다.")
+	;
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+	@Override
+	public ApiResponse<Void> getErrorResponse() {
+		return ApiResponse.onFailure(code, message);
+	}
+}

--- a/domain/src/main/java/com/pocket/domain/dto/oauth/KakaoLoginRequest.java
+++ b/domain/src/main/java/com/pocket/domain/dto/oauth/KakaoLoginRequest.java
@@ -1,4 +1,4 @@
-package com.pocket.domain.dto;
+package com.pocket.domain.dto.oauth;
 
 public record KakaoLoginRequest(
         String idToken

--- a/domain/src/main/java/com/pocket/domain/dto/oauth/OidcDecodePayload.java
+++ b/domain/src/main/java/com/pocket/domain/dto/oauth/OidcDecodePayload.java
@@ -1,4 +1,4 @@
-package com.pocket.domain.dto;
+package com.pocket.domain.dto.oauth;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/domain/src/main/java/com/pocket/domain/dto/oauth/OidcPublicKeyListResponse.java
+++ b/domain/src/main/java/com/pocket/domain/dto/oauth/OidcPublicKeyListResponse.java
@@ -1,4 +1,4 @@
-package com.pocket.domain.dto;
+package com.pocket.domain.dto.oauth;
 
 import java.util.List;
 

--- a/domain/src/main/java/com/pocket/domain/dto/oauth/OidcPublicKeyResponse.java
+++ b/domain/src/main/java/com/pocket/domain/dto/oauth/OidcPublicKeyResponse.java
@@ -1,4 +1,4 @@
-package com.pocket.domain.dto;
+package com.pocket.domain.dto.oauth;
 
 public record OidcPublicKeyResponse(
         String kid,

--- a/domain/src/main/java/com/pocket/domain/dto/user/LoginAddResponse.java
+++ b/domain/src/main/java/com/pocket/domain/dto/user/LoginAddResponse.java
@@ -1,9 +1,11 @@
-package com.pocket.domain.dto;
+package com.pocket.domain.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "로그인 후 토큰 응답")
-public record LoginResponse(
+public record LoginAddResponse(
+        String nickname,
+        String picture,
+        Boolean existYn,
         @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs", defaultValue = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs")
         String accessToken,
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs", defaultValue = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs")

--- a/domain/src/main/java/com/pocket/domain/dto/user/LoginResponse.java
+++ b/domain/src/main/java/com/pocket/domain/dto/user/LoginResponse.java
@@ -1,11 +1,9 @@
-package com.pocket.domain.dto;
+package com.pocket.domain.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record LoginAddResponse(
-        String nickname,
-        String picture,
-        Boolean existYn,
+@Schema(description = "로그인 후 토큰 응답")
+public record LoginResponse(
         @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs", defaultValue = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs")
         String accessToken,
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs", defaultValue = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIs")

--- a/domain/src/main/java/com/pocket/domain/dto/user/UserInfoDTO.java
+++ b/domain/src/main/java/com/pocket/domain/dto/user/UserInfoDTO.java
@@ -1,0 +1,8 @@
+package com.pocket.domain.dto.user;
+
+public record UserInfoDTO(
+        String name,
+        String email,
+        String image
+) {
+}

--- a/domain/src/main/java/com/pocket/domain/entity/BaseEntity.java
+++ b/domain/src/main/java/com/pocket/domain/entity/BaseEntity.java
@@ -2,6 +2,8 @@ package com.pocket.domain.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -19,4 +21,15 @@ public abstract class BaseEntity {
 
     @LastModifiedDate
     protected LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/domain/src/main/java/com/pocket/domain/entity/User.java
+++ b/domain/src/main/java/com/pocket/domain/entity/User.java
@@ -1,6 +1,6 @@
 package com.pocket.domain.entity;
 
-import com.pocket.domain.dto.OidcDecodePayload;
+import com.pocket.domain.dto.oauth.OidcDecodePayload;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 

--- a/domain/src/main/java/com/pocket/domain/port/user/LoadUserInfoPort.java
+++ b/domain/src/main/java/com/pocket/domain/port/user/LoadUserInfoPort.java
@@ -1,0 +1,8 @@
+package com.pocket.domain.port.user;
+
+import com.pocket.domain.dto.user.UserInfoDTO;
+
+public interface LoadUserInfoPort {
+
+    UserInfoDTO loadUserInfo(String name);
+}

--- a/domain/src/main/java/com/pocket/domain/service/user/UserQueryService.java
+++ b/domain/src/main/java/com/pocket/domain/service/user/UserQueryService.java
@@ -1,0 +1,18 @@
+package com.pocket.domain.service.user;
+
+import com.pocket.domain.dto.user.UserInfoDTO;
+import com.pocket.domain.port.user.LoadUserInfoPort;
+import com.pocket.domain.usecase.user.LoginUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryService implements LoginUseCase {
+
+    private final LoadUserInfoPort loadUserInfoPort;
+
+    public UserInfoDTO getUserInfo(String name) {
+        return loadUserInfoPort.loadUserInfo(name);
+    }
+}

--- a/domain/src/main/java/com/pocket/domain/usecase/user/LoginUseCase.java
+++ b/domain/src/main/java/com/pocket/domain/usecase/user/LoginUseCase.java
@@ -1,0 +1,8 @@
+package com.pocket.domain.usecase.user;
+
+import com.pocket.domain.dto.user.UserInfoDTO;
+
+public interface LoginUseCase {
+
+    UserInfoDTO getUserInfo(String name);
+}

--- a/inbounds/src/main/java/com/pocket/inbounds/user/presentation/UserController.java
+++ b/inbounds/src/main/java/com/pocket/inbounds/user/presentation/UserController.java
@@ -1,0 +1,30 @@
+package com.pocket.inbounds.user.presentation;
+
+import com.pocket.core.aop.annotation.NameAuthenticated;
+import com.pocket.core.exception.common.ApplicationResponse;
+import com.pocket.domain.dto.user.UserInfoDTO;
+import com.pocket.domain.usecase.user.LoginUseCase;
+import com.pocket.inbounds.user.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/api/user")
+public class UserController implements UserControllerDocs {
+
+    private final LoginUseCase loginUseCase;
+
+    @GetMapping
+//    @NameAuthenticated
+    public ApplicationResponse<UserResponse> getUserInfo(
+            @AuthenticationPrincipal UserInfoDTO userInfoDTO
+    ) {
+
+        UserResponse response = new UserResponse(userInfoDTO.name(), userInfoDTO.email(), userInfoDTO.image());
+        return ApplicationResponse.ok(response);
+    }
+}

--- a/inbounds/src/main/java/com/pocket/inbounds/user/presentation/UserControllerDocs.java
+++ b/inbounds/src/main/java/com/pocket/inbounds/user/presentation/UserControllerDocs.java
@@ -1,0 +1,28 @@
+package com.pocket.inbounds.user.presentation;
+
+import com.pocket.core.exception.common.ApplicationResponse;
+import com.pocket.domain.dto.user.UserInfoDTO;
+import com.pocket.inbounds.user.response.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.ErrorResponse;
+
+@Tag(name = "User", description = "User API")
+public interface UserControllerDocs {
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "사용자 정보 제공", description = "사용자 정보 전달 API")
+    ApplicationResponse<UserResponse> getUserInfo(
+            @AuthenticationPrincipal UserInfoDTO userInfoDTO);
+}

--- a/inbounds/src/main/java/com/pocket/inbounds/user/response/UserResponse.java
+++ b/inbounds/src/main/java/com/pocket/inbounds/user/response/UserResponse.java
@@ -1,0 +1,10 @@
+package com.pocket.inbounds.user.response;
+
+import com.pocket.domain.dto.user.UserInfoDTO;
+
+public record UserResponse(
+        String name,
+        String email,
+        String image
+) {
+}

--- a/outbound/src/main/java/com/pocket/outbound/adapter/authentication/OAuthLoginSuccessHandler.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/authentication/OAuthLoginSuccessHandler.java
@@ -37,6 +37,7 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
                     .toUriString();
 
             response.sendRedirect(encodedRedirectUrl);
+
         } else {
             // 인증 타입이 OidcUser가 아닐 경우 처리
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Authentication principal is not an instance of OidcUser");

--- a/outbound/src/main/java/com/pocket/outbound/adapter/oauth/KakaoIdTokenDecodeAdapter.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/oauth/KakaoIdTokenDecodeAdapter.java
@@ -1,10 +1,10 @@
-package com.pocket.outbound.adapter;
+package com.pocket.outbound.adapter.oauth;
 
 import com.nimbusds.jose.shaded.gson.JsonObject;
 import com.nimbusds.jose.shaded.gson.JsonParser;
 import com.pocket.core.exception.jwt.SecurityCustomException;
 import com.pocket.core.exception.jwt.SecurityErrorCode;
-import com.pocket.domain.dto.OidcDecodePayload;
+import com.pocket.domain.dto.oauth.OidcDecodePayload;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;

--- a/outbound/src/main/java/com/pocket/outbound/adapter/oauth/KakaoLoginAdapter.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/oauth/KakaoLoginAdapter.java
@@ -1,6 +1,6 @@
-package com.pocket.outbound.adapter;
+package com.pocket.outbound.adapter.oauth;
 
-import com.pocket.domain.dto.OidcDecodePayload;
+import com.pocket.domain.dto.oauth.OidcDecodePayload;
 import com.pocket.domain.entity.User;
 import com.pocket.outbound.entity.JpaUser;
 import com.pocket.outbound.repository.UserRepository;
@@ -39,19 +39,17 @@ public class KakaoLoginAdapter extends OidcUserService {
             log.debug("Decoded Payload: {}", oidcDecodePayload);
 
             // User 존재 여부 확인 및 조회
-            JpaUser user = userRepository.findByUserSubId(oidcDecodePayload.email())
+            userRepository.findByUserSubId(oidcDecodePayload.sub())
                     .orElseGet(() -> {
                         User newUser = User.createSocialUser(oidcDecodePayload);
                         JpaUser savedUser = JpaUser.createUser(newUser);
                         return userRepository.save(savedUser);
                     });
 
-            OidcUser oidcUser = new DefaultOidcUser(
+            return new DefaultOidcUser(
                     Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
                     userRequest.getIdToken()
             );
-
-            return oidcUser;
 
         } catch (Exception e) {
             log.error("Error loading user from OAuth2 user request: {}", e.getMessage(), e);

--- a/outbound/src/main/java/com/pocket/outbound/adapter/user/UserAdapter.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/user/UserAdapter.java
@@ -1,0 +1,31 @@
+package com.pocket.outbound.adapter.user;
+
+import com.pocket.core.exception.user.UserCustomException;
+import com.pocket.core.exception.user.UserErrorCode;
+import com.pocket.domain.dto.user.UserInfoDTO;
+import com.pocket.domain.port.user.LoadUserInfoPort;
+import com.pocket.outbound.entity.JpaUser;
+import com.pocket.outbound.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdapter implements LoadUserInfoPort {
+
+    private final UserRepository userRepository;
+
+    public UserInfoDTO loadUserInfo(String name) {
+        JpaUser user = userRepository.findByUserName(name)
+                .orElseThrow(() -> new UserCustomException(UserErrorCode.NO_USER_INFO));
+
+        return new UserInfoDTO(user.getUser().getName(), user.getUser().getEmail(), user.getUser().getPicture());
+    }
+
+    public UserInfoDTO loadUserInfoByEmail(String email) {
+        JpaUser user = userRepository.findByUserEmail(email)
+                .orElseThrow(() -> new UserCustomException(UserErrorCode.NO_USER_INFO));
+
+        return new UserInfoDTO(user.getUser().getName(), user.getUser().getEmail(), user.getUser().getPicture());
+    }
+}

--- a/outbound/src/main/java/com/pocket/outbound/config/SecurityConfig.java
+++ b/outbound/src/main/java/com/pocket/outbound/config/SecurityConfig.java
@@ -2,9 +2,10 @@ package com.pocket.outbound.config;
 
 import com.pocket.core.exception.jwt.JwtAccessDeniedHandler;
 import com.pocket.core.exception.jwt.JwtAuthenticationEntryPoint;
-import com.pocket.outbound.adapter.KakaoLoginAdapter;
+import com.pocket.outbound.adapter.oauth.KakaoLoginAdapter;
 import com.pocket.outbound.adapter.authentication.OAuthLoginFailureHandler;
 import com.pocket.outbound.adapter.authentication.OAuthLoginSuccessHandler;
+import com.pocket.outbound.util.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -32,6 +34,7 @@ public class SecurityConfig {
     private final OAuthLoginSuccessHandler oAuth2SuccessHandler;
     private final OAuthLoginFailureHandler oAuth2FailureHandler;
 
+    private final JwtFilter jwtFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -47,11 +50,9 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .authorizeHttpRequests(authz -> {
-                    authz.requestMatchers("/").permitAll();
                     authz.requestMatchers("/swagger-ui/**"
                             , "/swagger-resources/**"
                             , "/v3/api-docs/**").permitAll();
-                    authz.requestMatchers(PathRequest.toH2Console()).permitAll();
                     authz.anyRequest().authenticated();
                 })
 
@@ -60,6 +61,9 @@ public class SecurityConfig {
                                 .oidcUserService(kakaoLoginAdapter))
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler(oAuth2FailureHandler))
+
+                .addFilterAt(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
 
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/outbound/src/main/java/com/pocket/outbound/decoder/OidcJwtDecoder.java
+++ b/outbound/src/main/java/com/pocket/outbound/decoder/OidcJwtDecoder.java
@@ -2,7 +2,7 @@ package com.pocket.outbound.decoder;
 
 import com.pocket.core.exception.jwt.SecurityCustomException;
 import com.pocket.core.exception.jwt.SecurityErrorCode;
-import com.pocket.domain.dto.OidcDecodePayload;
+import com.pocket.domain.dto.oauth.OidcDecodePayload;
 import io.jsonwebtoken.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/outbound/src/main/java/com/pocket/outbound/infrastructure/KakaoOidcKeyClient.java
+++ b/outbound/src/main/java/com/pocket/outbound/infrastructure/KakaoOidcKeyClient.java
@@ -1,6 +1,6 @@
 package com.pocket.outbound.infrastructure;
 
-import com.pocket.domain.dto.OidcPublicKeyListResponse;
+import com.pocket.domain.dto.oauth.OidcPublicKeyListResponse;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/outbound/src/main/java/com/pocket/outbound/repository/UserRepository.java
+++ b/outbound/src/main/java/com/pocket/outbound/repository/UserRepository.java
@@ -8,4 +8,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<JpaUser, Long> {
 
     Optional<JpaUser> findByUserSubId(String subId);
+
+    Optional<JpaUser> findByUserName(String name);
+
+    Optional<JpaUser> findByUserEmail(String email);
 }

--- a/outbound/src/main/java/com/pocket/outbound/util/JwtFilter.java
+++ b/outbound/src/main/java/com/pocket/outbound/util/JwtFilter.java
@@ -1,0 +1,41 @@
+package com.pocket.outbound.util;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+
+        String jwt = jwtUtil.resolveToken(request);
+
+        if (jwt != null) {
+            jwtUtil.validateToken(jwt);
+            setAuthentication(jwt);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private void setAuthentication(String accessToken) {
+        Authentication authentication = jwtUtil.resolveToken(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+}


### PR DESCRIPTION
## 🌍 이슈 번호
resolve #16 

## 📝 구현 내용
- 로그인 인증 기능
- nameauthenticated aop
- 로그인 사용자 정보 전달

## 🍀 확인해야 할 부분
- 아직 각 컴포넌트 별 어노테이션 생성 안됨
- token reissue 기능 미완