### PR TITLE
refactor: API별 비로그인, 로그인 권한 분리하기

### DIFF
--- a/outbound/src/main/java/com/pocket/outbound/config/SecurityConfig.java
+++ b/outbound/src/main/java/com/pocket/outbound/config/SecurityConfig.java
@@ -49,10 +49,21 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .authorizeHttpRequests(authz -> {
-                    authz.requestMatchers("/swagger-ui/**"
-                            , "/swagger-resources/**"
-                            , "/v3/api-docs/**"
-                            , "/v1/photobooth/**").permitAll();
+                    // 접근 허용
+                    authz.requestMatchers("/swagger-ui/**",
+                            "/swagger-resources/**",
+                            "/v3/api-docs/**",
+                            "/api/v1/photobooth/**",
+                            "/api/v1/review/**",
+                            "/api/v1/album/**",
+                            "/v1/public/**").permitAll();
+
+                    // 로그인 필요
+                    authz.requestMatchers("/v1/user/**",
+                            "/api/v1/album",
+                            "/api/v1/review").authenticated();
+
+                    // 그 외의 모든 요청은 인증 필요
                     authz.anyRequest().authenticated();
                 })
 
@@ -68,7 +79,6 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler));
-
 
         return http.build();
     }
@@ -93,3 +103,4 @@ public class SecurityConfig {
     }
 
 }
+


### PR DESCRIPTION
## 🌍 이슈 번호
#50 API별 비로그인, 로그인 권한 분리하기

## 📝 구현 내용

SecurityConfig에서 로그인 여부에 따라 API 접근을 분리

- 비로그인
    - 메인페이지(홈): 포토부스 정보 조회, 리뷰 조회 모두
- 로그인
    - 앨범 등록, 리뷰 등록
    - 앨범 페이지
    - 마이페이지

## 🍀 확인해야 할 부분

