### PR TITLE
Feat/#71 포토부스 찜 API 추가 & 수정

### DIFF
--- a/core/src/main/java/com/pocket/core/exception/photobooth/PhotoBoothErrorCode.java
+++ b/core/src/main/java/com/pocket/core/exception/photobooth/PhotoBoothErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PhotoBoothErrorCode implements BaseErrorCode {
     PHOTOBOOTH_NOT_FOUND(HttpStatus.BAD_REQUEST, "400", "해당 포토부스가 존재하지 않습니다."),
-    PHOTOBOOTHBRAND_NOT_FOUND(HttpStatus.BAD_REQUEST, "400", "해당 포토부스 브랜드가 존재하지 않습니다.");
+    PHOTOBOOTHBRAND_NOT_FOUND(HttpStatus.BAD_REQUEST, "400", "해당 포토부스 브랜드가 존재하지 않습니다."),
+    PHOTOBOOTHLIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "400", "찜한 포토부스가 아닙니다."),
+    PHOTOBOOTHLIKE_FOUND(HttpStatus.BAD_REQUEST, "400", "이미 찜한 포토부스 입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/domain/src/main/java/com/pocket/domain/port/photobooth/PhotoBoothCheckLikePort.java
+++ b/domain/src/main/java/com/pocket/domain/port/photobooth/PhotoBoothCheckLikePort.java
@@ -1,0 +1,9 @@
+package com.pocket.domain.port.photobooth;
+
+import com.pocket.domain.entity.photobooth.PhotoBooth;
+
+public interface PhotoBoothCheckLikePort {
+
+    Boolean checkLike(Long photoBoothId, String userEmail);
+
+}

--- a/domain/src/main/java/com/pocket/domain/port/photobooth/PhotoBoothDeleteLikePort.java
+++ b/domain/src/main/java/com/pocket/domain/port/photobooth/PhotoBoothDeleteLikePort.java
@@ -1,0 +1,9 @@
+package com.pocket.domain.port.photobooth;
+
+import com.pocket.domain.entity.photobooth.PhotoBooth;
+
+public interface PhotoBoothDeleteLikePort {
+
+    void deleteLike(Long photoBoothId, String userEmail);
+
+}

--- a/domain/src/main/java/com/pocket/domain/service/photobooth/PhotoBoothService.java
+++ b/domain/src/main/java/com/pocket/domain/service/photobooth/PhotoBoothService.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNameUseCase, PhotoBoothGetRatingUseCase, PhotoBoothSearchUseCase, PhotoBoothGetModalUseCase, PhotoBoothVisitedUseCase, PhotoBoothLikeUseCase, PhotoBoothGetLikeUseCase
+public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNameUseCase, PhotoBoothGetRatingUseCase, PhotoBoothSearchUseCase, PhotoBoothGetModalUseCase, PhotoBoothVisitedUseCase, PhotoBoothLikeUseCase, PhotoBoothGetLikeUseCase, PhotoBoothCheckLikeUseCase
 {
 
     private final PhotoBoothFindPort photoBoothFindPort;
@@ -24,6 +24,7 @@ public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNa
     private final PhotoBoothVisitedPort photoBoothVisitedPort;
     private final PhotoBoothLikePort photoBoothLikePort;
     private final PhotoBoothGetLikePort photoBoothGetLikePort;
+    private final PhotoBoothCheckLikePort photoBoothCheckLikePort;
 
     public PhotoBoothFindResponseDto findPhotoBoothResponse(Long id) {
         return photoBoothFindPort.findById(id);
@@ -55,12 +56,17 @@ public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNa
     }
 
     @Override
-    public void photoBoothLike(Long photoId, String userEmail) {
-        photoBoothLikePort.photoBoothLike(photoId, userEmail);
+    public void photoBoothLike(Long photoboothId, String userEmail) {
+        photoBoothLikePort.photoBoothLike(photoboothId, userEmail);
     }
 
     @Override
     public List<PhotoBoothLikeDto> getLikedPhotos(String userEmail) {
         return photoBoothGetLikePort.getLikedPhotos(userEmail);
+    }
+
+    @Override
+    public Boolean checkLike(Long photoBoothId, String userEmail) {
+        return photoBoothCheckLikePort.checkLike(photoBoothId, userEmail);
     }
 }

--- a/domain/src/main/java/com/pocket/domain/service/photobooth/PhotoBoothService.java
+++ b/domain/src/main/java/com/pocket/domain/service/photobooth/PhotoBoothService.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNameUseCase, PhotoBoothGetRatingUseCase, PhotoBoothSearchUseCase, PhotoBoothGetModalUseCase, PhotoBoothVisitedUseCase, PhotoBoothLikeUseCase, PhotoBoothGetLikeUseCase, PhotoBoothCheckLikeUseCase
+public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNameUseCase, PhotoBoothGetRatingUseCase, PhotoBoothSearchUseCase, PhotoBoothGetModalUseCase, PhotoBoothVisitedUseCase, PhotoBoothLikeUseCase, PhotoBoothGetLikeUseCase, PhotoBoothCheckLikeUseCase, PhotoBoothDeleteLikeUseCase
 {
 
     private final PhotoBoothFindPort photoBoothFindPort;
@@ -25,6 +25,7 @@ public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNa
     private final PhotoBoothLikePort photoBoothLikePort;
     private final PhotoBoothGetLikePort photoBoothGetLikePort;
     private final PhotoBoothCheckLikePort photoBoothCheckLikePort;
+    private final PhotoBoothDeleteLikePort photoBoothDeleteLikePort;
 
     public PhotoBoothFindResponseDto findPhotoBoothResponse(Long id) {
         return photoBoothFindPort.findById(id);
@@ -68,5 +69,10 @@ public class PhotoBoothService implements PhotoBoothFindUseCase, PhotoBoothGetNa
     @Override
     public Boolean checkLike(Long photoBoothId, String userEmail) {
         return photoBoothCheckLikePort.checkLike(photoBoothId, userEmail);
+    }
+
+    @Override
+    public void deleteLike(Long photoBoothId, String userEmail) {
+        photoBoothDeleteLikePort.deleteLike(photoBoothId, userEmail);
     }
 }

--- a/domain/src/main/java/com/pocket/domain/usecase/photobooth/PhotoBoothCheckLikeUseCase.java
+++ b/domain/src/main/java/com/pocket/domain/usecase/photobooth/PhotoBoothCheckLikeUseCase.java
@@ -1,0 +1,7 @@
+package com.pocket.domain.usecase.photobooth;
+
+public interface PhotoBoothCheckLikeUseCase {
+
+    Boolean checkLike(Long photoBoothId, String userEmail);
+
+}

--- a/domain/src/main/java/com/pocket/domain/usecase/photobooth/PhotoBoothDeleteLikeUseCase.java
+++ b/domain/src/main/java/com/pocket/domain/usecase/photobooth/PhotoBoothDeleteLikeUseCase.java
@@ -1,0 +1,7 @@
+package com.pocket.domain.usecase.photobooth;
+
+public interface PhotoBoothDeleteLikeUseCase {
+
+    void deleteLike(Long photoBoothId, String userEmail);
+
+}

--- a/inbounds/src/main/java/com/pocket/inbounds/photobooth/presentation/PhotoBoothController.java
+++ b/inbounds/src/main/java/com/pocket/inbounds/photobooth/presentation/PhotoBoothController.java
@@ -26,6 +26,7 @@ public class PhotoBoothController implements PhotoBoothControllerDocs {
     private final PhotoBoothLikeUseCase photoBoothLikeUseCase;
     private final PhotoBoothGetLikeUseCase photoBoothGetLikeUseCase;
     private final PhotoBoothCheckLikeUseCase photoBoothCheckLikeUseCase;
+    private final PhotoBoothDeleteLikeUseCase photoBoothDeleteLikeUseCase;
 
     @GetMapping("{id}")
     public ApplicationResponse<PhotoBoothFindResponseDto> getPhotoBoothById(@PathVariable("id") Long id) {
@@ -101,5 +102,14 @@ public class PhotoBoothController implements PhotoBoothControllerDocs {
     ) {
         Boolean response = photoBoothCheckLikeUseCase.checkLike(id, user.email());
         return ApplicationResponse.ok(response);
+    }
+
+    @DeleteMapping("/like/{id}")
+    public ApplicationResponse<String> deletePhotoBoothLike(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal UserInfoDTO user
+    ) {
+        photoBoothDeleteLikeUseCase.deleteLike(id, user.email());
+        return ApplicationResponse.ok("success");
     }
 }

--- a/inbounds/src/main/java/com/pocket/inbounds/photobooth/presentation/PhotoBoothController.java
+++ b/inbounds/src/main/java/com/pocket/inbounds/photobooth/presentation/PhotoBoothController.java
@@ -25,6 +25,7 @@ public class PhotoBoothController implements PhotoBoothControllerDocs {
     private final PhotoBoothVisitedUseCase photoBoothVisitedUseCase;
     private final PhotoBoothLikeUseCase photoBoothLikeUseCase;
     private final PhotoBoothGetLikeUseCase photoBoothGetLikeUseCase;
+    private final PhotoBoothCheckLikeUseCase photoBoothCheckLikeUseCase;
 
     @GetMapping("{id}")
     public ApplicationResponse<PhotoBoothFindResponseDto> getPhotoBoothById(@PathVariable("id") Long id) {
@@ -90,6 +91,15 @@ public class PhotoBoothController implements PhotoBoothControllerDocs {
             @AuthenticationPrincipal UserInfoDTO user
     ) {
         List<PhotoBoothLikeDto> response = photoBoothGetLikeUseCase.getLikedPhotos(user.email());
+        return ApplicationResponse.ok(response);
+    }
+
+    @GetMapping("/like/check/{id}")
+    public ApplicationResponse<Boolean> likePhotoBoothCheck(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal UserInfoDTO user
+    ) {
+        Boolean response = photoBoothCheckLikeUseCase.checkLike(id, user.email());
         return ApplicationResponse.ok(response);
     }
 }

--- a/inbounds/src/main/java/com/pocket/inbounds/photobooth/presentation/PhotoBoothControllerDocs.java
+++ b/inbounds/src/main/java/com/pocket/inbounds/photobooth/presentation/PhotoBoothControllerDocs.java
@@ -130,4 +130,30 @@ public interface PhotoBoothControllerDocs {
             @AuthenticationPrincipal UserInfoDTO user
     );
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "포토부스 찜 여부 확인", description = "찜한 포토부스인지 확인하는 API")
+    ApplicationResponse<Boolean> likePhotoBoothCheck(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal UserInfoDTO user
+    );
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "포토부스 찜 삭제", description = "포토부스 찜 삭제하는 API")
+    ApplicationResponse<String> deletePhotoBoothLike(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal UserInfoDTO user
+    );
+
 }

--- a/outbound/src/main/java/com/pocket/outbound/adapter/photobooth/adapter/PhotoBoothCheckLikeAdapter.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/photobooth/adapter/PhotoBoothCheckLikeAdapter.java
@@ -1,0 +1,23 @@
+package com.pocket.outbound.adapter.photobooth.adapter;
+
+import com.pocket.core.aop.annotation.AdapterService;
+import com.pocket.domain.port.photobooth.PhotoBoothCheckLikePort;
+import com.pocket.outbound.entity.photobooth.JpaLike;
+import com.pocket.outbound.repository.photobooth.LikeRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+
+@AdapterService
+@RequiredArgsConstructor
+public class PhotoBoothCheckLikeAdapter implements PhotoBoothCheckLikePort {
+
+    private final LikeRepository likeRepository;
+
+    @Override
+    public Boolean checkLike(Long photoBoothId, String userEmail) {
+        return likeRepository.findByUser_UserEmailAndPhotoBooth_Id(userEmail, photoBoothId).isPresent();
+    }
+
+}

--- a/outbound/src/main/java/com/pocket/outbound/adapter/photobooth/adapter/PhotoBoothDeleteLikeAdapter.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/photobooth/adapter/PhotoBoothDeleteLikeAdapter.java
@@ -1,0 +1,30 @@
+package com.pocket.outbound.adapter.photobooth.adapter;
+
+import com.pocket.core.aop.annotation.AdapterService;
+import com.pocket.core.exception.photobooth.PhotoBoothCustomException;
+import com.pocket.core.exception.photobooth.PhotoBoothErrorCode;
+import com.pocket.domain.port.photobooth.PhotoBoothDeleteLikePort;
+import com.pocket.outbound.entity.photobooth.JpaLike;
+import com.pocket.outbound.repository.photobooth.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@AdapterService
+@RequiredArgsConstructor
+public class PhotoBoothDeleteLikeAdapter implements PhotoBoothDeleteLikePort {
+
+    private final LikeRepository likeRepository;
+
+    @Override
+    @Transactional
+    public void deleteLike(Long photoBoothId, String userEmail) {
+        Optional<JpaLike> entity = likeRepository.findByUser_UserEmailAndPhotoBooth_Id(userEmail, photoBoothId);
+        if (entity.isPresent()) {
+            likeRepository.delete(entity.get());
+        } else {
+            throw new PhotoBoothCustomException(PhotoBoothErrorCode.PHOTOBOOTHLIKE_NOT_FOUND);
+        }
+    }
+}

--- a/outbound/src/main/java/com/pocket/outbound/adapter/photobooth/adapter/PhotoBoothLikeAdapter.java
+++ b/outbound/src/main/java/com/pocket/outbound/adapter/photobooth/adapter/PhotoBoothLikeAdapter.java
@@ -15,6 +15,8 @@ import com.pocket.outbound.repository.photobooth.LikeRepository;
 import com.pocket.outbound.repository.photobooth.PhotoBoothRepository;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 @AdapterService
 @RequiredArgsConstructor
 public class PhotoBoothLikeAdapter implements PhotoBoothLikePort {
@@ -25,6 +27,11 @@ public class PhotoBoothLikeAdapter implements PhotoBoothLikePort {
 
     @Override
     public void photoBoothLike(Long photoBoothId, String userEmail) {
+
+        Optional<JpaLike> entity = likeRepository.findByUser_UserEmailAndPhotoBooth_Id(userEmail, photoBoothId);
+        if (entity.isPresent()) {
+            throw new PhotoBoothCustomException(PhotoBoothErrorCode.PHOTOBOOTHLIKE_FOUND);
+        }
         JpaUser jpaUser = userRepository.findByUserEmail(userEmail)
                 .orElseThrow(() -> new UserCustomException(UserErrorCode.NO_USER_INFO));
 
@@ -32,6 +39,7 @@ public class PhotoBoothLikeAdapter implements PhotoBoothLikePort {
                 .orElseThrow(() -> new PhotoBoothCustomException((PhotoBoothErrorCode.PHOTOBOOTH_NOT_FOUND)));
 
         JpaLike jpaLike = JpaLike.createLike(jpaUser, jpaPhotoBooth);
+
         likeRepository.save(jpaLike);
     }
 }

--- a/outbound/src/main/java/com/pocket/outbound/repository/photobooth/LikeRepository.java
+++ b/outbound/src/main/java/com/pocket/outbound/repository/photobooth/LikeRepository.java
@@ -4,9 +4,12 @@ import com.pocket.outbound.entity.photobooth.JpaLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<JpaLike, Long> {
 
     List<JpaLike> findByUser_UserEmail(String userEmail);
+
+    Optional<JpaLike> findByUser_UserEmailAndPhotoBooth_Id(String userEmail, Long photoBoothId);
 
 }


### PR DESCRIPTION
## 🌍 이슈 번호
#71 

## 📝 구현 내용

1. 포토부스에서 사용자 토큰이랑 booth id 주면 좋아요를 했는지 여부를 알 수있는 api
2. 찜 취소 api
3. 찜 기능 로직 수정 (이미 찜한 포토부스이면 에러를 발생)

## 🍀 확인해야 할 부분
